### PR TITLE
[Build] Do not override the libstdc++ ABI by default

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -205,7 +205,6 @@ jobs:
 
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
           -DOPENASSETIO_ENABLE_TESTS=ON
-          -DOPENASSETIO_GLIBCXX_USE_CXX11_ABI=OFF
 
           cmake --build build --parallel --config RelWithDebInfo
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,8 +152,7 @@ option(OPENASSETIO_ENABLE_IPO
 option(OPENASSETIO_ENABLE_POSITION_INDEPENDENT_CODE
     "Enable position independent code for static library builds" ON)
 
-# Disable C++11 ABI by default, as per current VFX reference
-# platform(s), but allow optionally enabling.
+# Allow overriding the libstdc++ ABI from the system default.
 # For reference, note that the default varies by platform, e.g.
 # * CentOS 7.9.2009's GCC 6.3, `_GLIBCXX_USE_CXX11_ABI` is
 #   always `0` and cannot be overridden.
@@ -161,7 +160,8 @@ option(OPENASSETIO_ENABLE_POSITION_INDEPENDENT_CODE
 #   to `1`, but can be overridden.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
     CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
-    option(OPENASSETIO_GLIBCXX_USE_CXX11_ABI "For gcc, use the new C++11 library ABI" OFF)
+    set(OPENASSETIO_GLIBCXX_USE_CXX11_ABI "" CACHE STRING
+        "For libstdc++, use the non-deprecated library ABI - blank for auto (default)")
 endif ()
 
 # Whether to use RPATH or RUNPATH runtime search path behavior.
@@ -351,7 +351,9 @@ message(STATUS "Warnings as errors                 = ${OPENASSETIO_WARNINGS_AS_E
 message(STATUS "Interprocedural optimization       = ${OPENASSETIO_ENABLE_IPO}")
 message(STATUS "Enable PIC for static libs         = ${OPENASSETIO_ENABLE_POSITION_INDEPENDENT_CODE}")
 if (IS_GCC_OR_CLANG)
-    message(STATUS "New C++11 ABI for gcc              = ${OPENASSETIO_GLIBCXX_USE_CXX11_ABI}")
+    if (DEFINED OPENASSETIO_GLIBCXX_USE_CXX11_ABI)
+        message(STATUS "libstdc++ non-deprecated ABI       = ${OPENASSETIO_GLIBCXX_USE_CXX11_ABI}")
+    endif ()
     message(STATUS "RUNPATH rather than RPATH          = ${OPENASSETIO_ENABLE_NEW_DTAGS}")
     message(STATUS "Coverage reports                   = ${OPENASSETIO_ENABLE_COVERAGE}")
     message(STATUS "libstdc++ debug mode               = ${OPENASSETIO_ENABLE_GLIBCXX_DEBUG}")

--- a/cmake/DefaultTargetProperties.cmake
+++ b/cmake/DefaultTargetProperties.cmake
@@ -72,9 +72,10 @@ function(openassetio_set_default_target_properties target_name)
         target_link_options(${target_name} PRIVATE ${_exclude_all_libs_linker_flag})
     endif ()
 
-    # Whether to use the old or new C++ ABI with gcc.
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
-        CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
+    # Whether to use the old or new C++ ABI with libstdc++. Not defined
+    # means not relevant, blank means use the system/compiler default.
+    if (DEFINED OPENASSETIO_GLIBCXX_USE_CXX11_ABI AND
+        NOT OPENASSETIO_GLIBCXX_USE_CXX11_ABI STREQUAL "")
         if (OPENASSETIO_GLIBCXX_USE_CXX11_ABI)
             target_compile_definitions(${target_name} PRIVATE _GLIBCXX_USE_CXX11_ABI=1)
         else ()

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -179,28 +179,28 @@ about [here](SANDBOXED_BUILDS.md).
 OpenAssetIO provides several custom CMake options to control the
 behaviour of the build.
 
-| Option                                            | Description                                                           | Default |
-|---------------------------------------------------|-----------------------------------------------------------------------|---------|
-| `BUILD_SHARED_LIBS`                               | `ON` to build shared libraries. `OFF` to build static libraries.      | `ON`    |
-| `OPENASSETIO_ENABLE_PYTHON`                       | Additionally build python bindings                                    | `ON`    |
-| `OPENASSETIO_ENABLE_PYTHON_INSTALL_DIST_INFO`     | Create a dist-info metadata directory alongside Python installation   | `ON`    |
-| `OPENASSETIO_ENABLE_C`                            | Additionally build C bindings                                         | `OFF`   |
-| `OPENASSETIO_ENABLE_TESTS`                        | Additionally build tests                                              | `OFF`   |
-| `OPENASSETIO_ENABLE_PYTHON_TEST_VENV`             | Automatically create environment when running tests                   | `ON`    |
-| `OPENASSETIO_WARNINGS_AS_ERRORS`                  | Treat compiler warnings as errors                                     | `OFF`   |
-| `OPENASSETIO_ENABLE_IPO`                          | Enable Interprocedural Optimization, aka Link Time Optimization (LTO) | `ON`    |
-| `OPENASSETIO_ENABLE_POSITION_INDEPENDENT_CODE`    | Enable position independent code for static library builds            | `ON`    |
-| `OPENASSETIO_GLIBCXX_USE_CXX11_ABI`               | When building under gcc, use the new C++11 library ABI                | `OFF`   |
-| `OPENASSETIO_ENABLE_NEW_DTAGS`                    | Set RUNPATH, overriding RPATH, on linux platforms                     | `OFF`   |
-| `OPENASSETIO_ENABLE_COVERAGE`                     | Enable coverage reporting for gcc/clang                               | `OFF`   |
-| `OPENASSETIO_ENABLE_SANITIZER_ADDRESS`            | Enable address sanitizer                                              | `OFF`   |
-| `OPENASSETIO_ENABLE_SANITIZER_LEAK`               | Enable leak sanitizer                                                 | `OFF`   |
-| `OPENASSETIO_ENABLE_SANITIZER_UNDEFINED_BEHAVIOR` | Enable undefined behavior sanitizer                                   | `OFF`   |
-| `OPENASSETIO_ENABLE_SANITIZER_THREAD`             | Enable thread sanitizer                                               | `OFF`   |
-| `OPENASSETIO_ENABLE_SANITIZER_MEMORY`             | Enable memory sanitizer                                               | `OFF`   |
-| `OPENASSETIO_ENABLE_CLANG_TIDY`                   | Enable clang-tidy analysis during build                               | `OFF`   |
-| `OPENASSETIO_ENABLE_CPPLINT`                      | Enable cpplint linter during build                                    | `OFF`   |
-| `OPENASSETIO_ENABLE_CMAKE_LINT`                   | Enable cmake-lint linter during build                                 | `OFF`   |
+| Option                                            | Description                                                           | Default     |
+|---------------------------------------------------|-----------------------------------------------------------------------|-------------|
+| `BUILD_SHARED_LIBS`                               | `ON` to build shared libraries. `OFF` to build static libraries.      | `ON`        |
+| `OPENASSETIO_ENABLE_PYTHON`                       | Additionally build python bindings                                    | `ON`        |
+| `OPENASSETIO_ENABLE_PYTHON_INSTALL_DIST_INFO`     | Create a dist-info metadata directory alongside Python installation   | `ON`        |
+| `OPENASSETIO_ENABLE_C`                            | Additionally build C bindings                                         | `OFF`       |
+| `OPENASSETIO_ENABLE_TESTS`                        | Additionally build tests                                              | `OFF`       |
+| `OPENASSETIO_ENABLE_PYTHON_TEST_VENV`             | Automatically create environment when running tests                   | `ON`        |
+| `OPENASSETIO_WARNINGS_AS_ERRORS`                  | Treat compiler warnings as errors                                     | `OFF`       |
+| `OPENASSETIO_ENABLE_IPO`                          | Enable Interprocedural Optimization, aka Link Time Optimization (LTO) | `ON`        |
+| `OPENASSETIO_ENABLE_POSITION_INDEPENDENT_CODE`    | Enable position independent code for static library builds            | `ON`        |
+| `OPENASSETIO_GLIBCXX_USE_CXX11_ABI`               | When building using libstdc++, use the non-deprecated ABI             | `""` (auto) |
+| `OPENASSETIO_ENABLE_NEW_DTAGS`                    | Set RUNPATH, overriding RPATH, on linux platforms                     | `OFF`       |
+| `OPENASSETIO_ENABLE_COVERAGE`                     | Enable coverage reporting for gcc/clang                               | `OFF`       |
+| `OPENASSETIO_ENABLE_SANITIZER_ADDRESS`            | Enable address sanitizer                                              | `OFF`       |
+| `OPENASSETIO_ENABLE_SANITIZER_LEAK`               | Enable leak sanitizer                                                 | `OFF`       |
+| `OPENASSETIO_ENABLE_SANITIZER_UNDEFINED_BEHAVIOR` | Enable undefined behavior sanitizer                                   | `OFF`       |
+| `OPENASSETIO_ENABLE_SANITIZER_THREAD`             | Enable thread sanitizer                                               | `OFF`       |
+| `OPENASSETIO_ENABLE_SANITIZER_MEMORY`             | Enable memory sanitizer                                               | `OFF`       |
+| `OPENASSETIO_ENABLE_CLANG_TIDY`                   | Enable clang-tidy analysis during build                               | `OFF`       |
+| `OPENASSETIO_ENABLE_CPPLINT`                      | Enable cpplint linter during build                                    | `OFF`       |
+| `OPENASSETIO_ENABLE_CMAKE_LINT`                   | Enable cmake-lint linter during build                                 | `OFF`       |
 
 ### Presets
 

--- a/examples/manager/SimpleCppManager/README.md
+++ b/examples/manager/SimpleCppManager/README.md
@@ -46,7 +46,7 @@ project, and assuming a POSIX host
 
 ```sh
 export CMAKE_PREFIX_PATH=/path/to/OpenAssetIO/dist
-cmake -S . -B build -DOPENASSETIO_GLIBCXX_USE_CXX11_ABI=OFF
+cmake -S . -B build
 cmake --build build --parallel
 cmake --install build --prefix /path/to/OpenAssetIO/plugins
 ```

--- a/resources/build/bootstrap-cibuildwheel-manylinux-2014.sh
+++ b/resources/build/bootstrap-cibuildwheel-manylinux-2014.sh
@@ -17,9 +17,10 @@ export CONAN_USER_HOME="$HOME/conan"
 # Create default conan profile so we can configure it before instlibXcomposite-develall.
 # Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
-# Use old C++11 ABI as per VFX Reference Platform CY2022. Not strictly
-# necessary as this is the default for conan, but we can't be certain
-# it'll remain the default in future.
+# TODO(DF): The libstdc++ ABI should be set to match the VFX Reference
+# Platform we're targeting, which is different for different versions of
+# Python. Below, we choose deprecated ABI, which is for CY22 and below
+# (and matches the default of the manylinux2014 CentOS 7-based image).
 conan profile update settings.compiler.libcxx=libstdc++ default
 # If we need to pin a package to a specific Conan recipe revision, then
 # we need to explicitly opt-in to this functionality.

--- a/resources/build/bootstrap-ubuntu-20.04.sh
+++ b/resources/build/bootstrap-ubuntu-20.04.sh
@@ -14,10 +14,12 @@ export CONAN_USER_HOME="$HOME/conan"
 # Create default conan profile so we can configure it before install.
 # Use --force so that if it already exists we don't error out.
 conan profile new default --detect --force
-# Use old C++11 ABI as per VFX Reference Platform CY2022. Not strictly
-# necessary as this is the default for conan, but we can't be certain
-# it'll remain the default in future.
-conan profile update settings.compiler.libcxx=libstdc++ default
+# Use non-deprecated libstdc++ ABI. This is a bit of a mismatch between
+# VFX Reference Platform. Ubuntu 20.04 ships with GCC 9, which seems to
+# imply VFX CY22 and thus deprecated ABI. However, OpenAssetIO will, by
+# default, use the system default ABI, which on Ubuntu 20.04 is the
+# non-deprecated ABI.
+conan profile update settings.compiler.libcxx=libstdc++11 default
 # If we need to pin a package to a specific Conan recipe revision, then
 # we need to explicitly opt-in to this functionality.
 conan config set general.revisions_enabled=True


### PR DESCRIPTION
Closes #1353. All VFX Reference Platform versions after CY22 specify that the non-deprecated ABI for libstdc++ should be used. This means that the default when building OpenAssetIO is wrong in those cases.

So in order to make a best guess at what the user wants when building OpenAssetIO, simply don't enforce any ABI by default, so that the system default is used.

The option remains available and works the same way for those that need to be explicit.

This means CI diverges from CY22 unless we explicitly set the libstdc++ ABI. However, a CI is due to be upgraded to CY23+ in #812. So don't bother forcing ABI only to change it again in the near future.

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
